### PR TITLE
OpenBSD minimize don't have any effect.

### DIFF
--- a/openbsd.json
+++ b/openbsd.json
@@ -160,8 +160,7 @@
         "script/virtualbox.sh",
         "script/parallels.sh",
         "custom-script.sh",
-        "script/cleanup.sh",
-        "script/minimize.sh"
+        "script/cleanup.sh"
       ],
       "type": "shell"
     }


### PR DESCRIPTION
The boxes end up at the exact same size with and w/o `minimize.sh`. So better don't use it since it take some time for nothing.
