### PR TITLE
Don't fail freebsd-update when no patches is available.

### DIFF
--- a/script/freebsd/update.sh
+++ b/script/freebsd/update.sh
@@ -19,8 +19,11 @@ fi
 
 # Update FreeBSD
 # NOTE: this will fail if there aren't any patches available for the release yet
-env PAGER=/bin/cat $freebsd_update fetch;
-env PAGER=/bin/cat $freebsd_update install;
+env PAGER=/bin/cat $freebsd_update fetch | tee /tmp/freebsd-update.log;
+grep -q "No updates needed to update system" /tmp/freebsd-update.log;
+if [ "$?" -ne 0 ]; then
+  env PAGER=/bin/cat $freebsd_update install;
+fi
 
 # Always use pkgng - pkg_add is EOL as of 1 September 2014
 echo "==> Bootstrap pkg";


### PR DESCRIPTION
`freebsd-update install` will fail if there are no patches to install. To avoid this only run `install` if `fetch` report that there are patches to install.
