### PR TITLE
Cleanup FreeBSD templates and scripts

### DIFF
--- a/freebsd.json
+++ b/freebsd.json
@@ -30,7 +30,7 @@
         "{{ user `iso_url` }}"
       ],
       "output_directory": "output-{{ user `vm_name` }}-virtualbox-iso",
-      "shutdown_command": "su -m root -c 'shutdown -p now'",
+      "shutdown_command": "echo '{{ user `ssh_password` }}' | su -m root -c 'shutdown -p now'",
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
@@ -70,7 +70,7 @@
         "{{ user `iso_url` }}"
       ],
       "output_directory": "output-{{ user `vm_name` }}-vmware-iso",
-      "shutdown_command": "su -m root -c 'shutdown -p now'",
+      "shutdown_command": "echo '{{ user `ssh_password` }}' | su -m root -c 'shutdown -p now'",
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
@@ -124,7 +124,7 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "su -m root -c 'shutdown -p now'",
+      "shutdown_command": "echo '{{ user `ssh_password` }}' | su -m root -c 'shutdown -p now'",
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_username": "{{ user `ssh_username` }}",
       "ssh_wait_timeout": "10000s",
@@ -157,7 +157,7 @@
         "rsync_proxy={{user `rsync_proxy`}}",
         "no_proxy={{user `no_proxy`}}"
       ],
-      "execute_command": "{{.Vars}} su -m root -c 'sh -eux {{.Path}}'",
+      "execute_command": "echo '{{ user `ssh_password` }}' | {{.Vars}} su -m root -c 'sh -eux {{.Path}}'",
       "scripts": [
         "script/freebsd/update.sh",
         "script/freebsd/postinstall.sh",

--- a/http/installerconfig.freebsd
+++ b/http/installerconfig.freebsd
@@ -43,7 +43,7 @@ touch /etc/fstab
 
 # Set up user accounts
 echo "vagrant" | pw -V /etc useradd vagrant -h 0 -s /bin/sh -G wheel -d /home/vagrant -c "Vagrant User"
-echo "vagrant" | pw -V /etc usermod root
+echo "vagrant" | pw -V /etc usermod root -h 0
 
 mkdir -p /home/vagrant
 chown 1001:1001 /home/vagrant

--- a/script/freebsd/virtualbox.sh
+++ b/script/freebsd/virtualbox.sh
@@ -5,9 +5,6 @@ freebsd_major="$(uname -r | awk -F. '{print $1}')"
 if [ "$PACKER_BUILDER_TYPE" = "virtualbox-iso" ]; then
     echo "==> Installing VirtualBox guest additions"
 
-    # Disable X11 because vagrants are (usually) headless
-    echo 'WITHOUT_X11="YES"' >> /etc/make.conf
-
     pkg install -y virtualbox-ose-additions;
 
     echo 'vboxdrv_load="YES"' >>/boot/loader.conf;
@@ -29,5 +26,5 @@ if [ "$PACKER_BUILDER_TYPE" = "virtualbox-iso" ]; then
     echo 'ifconfig_vtnet3_name="em3"' >>/etc/rc.conf;
 
     pw groupadd vboxusers;
-    pw groupmod vboxusers -m vagrant;
+    pw groupmod vboxusers -m $SSH_USERNAME;
 fi


### PR DESCRIPTION
- Removed hardcoded `vagrant` username.
- Removed duplicate addition of `WITHOUT_X11="YES"` in `/etc/make.conf`
- Properly set `root` password to _vagrant_.
