### PR TITLE
Updated to DragonFly BSD 4.6.1

### DIFF
--- a/dragonflybsd.json
+++ b/dragonflybsd.json
@@ -75,6 +75,50 @@
         "memsize": "{{ user `memory` }}",
         "numvcpus": "{{ user `cpus` }}"
       }
+    },
+    {
+      "boot_command": [
+        "1",
+        "<wait10><wait10><wait10><wait10>",
+        "root<enter>dhclient em0<enter><wait>",
+        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `install_path` }}",
+        " && sh /tmp/install.sh ad0 {{ user `hostname`}} vagrant",
+        " {{ user `ssh_password` }} \"{{ user `ssh_fullname` }}\"<enter>"
+      ],
+      "boot_wait": "6s",
+      "disk_size": "{{ user `disk_size` }}",
+      "guest_os_type": "{{ user `parallels_guest_os_type` }}",
+      "hard_drive_interface": "ide",
+      "http_directory": "http",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
+      "iso_urls": [
+        "{{ user `iso_path` }}/{{ user `iso_name` }}",
+        "{{ user `iso_url` }}"
+      ],
+      "output_directory": "output-{{ user `vm_name` }}-parallels-iso",
+      "parallels_tools_mode": "disable",
+      "prlctl": [
+        [
+          "set", "{{.Name}}", "--memsize", "{{ user `memory` }}"
+        ],
+        [
+          "set", "{{.Name}}", "--cpus", "{{ user `cpus` }}"
+        ],
+        [
+          "set", "{{.Name}}", "--device-del", "fdd0"
+        ],
+        [
+          "set", "{{.Name}}", "--device-del", "parallel0"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "sudo shutdown -p now",
+      "ssh_password": "{{ user `ssh_password` }}",
+      "ssh_username": "{{ user `ssh_username` }}",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
+      "vm_name": "{{ user `vm_name` }}"
     }
   ],
   "post-processors": [

--- a/dragonflybsd46.json
+++ b/dragonflybsd46.json
@@ -1,8 +1,8 @@
 {
   "_comment": "Build with `packer build -var-file=dragonflybsd46.json dragonflybsd.json`",
-  "iso_checksum": "a375d21d9010ed7bcc4a232f48387df1bdadd49a1075f2fd05f641a89998d330",
-  "iso_name": "dfly-x86_64-4.6.0_REL.iso",
-  "iso_url": "http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-4.6.0_REL.iso.bz2",
+  "iso_checksum": "cf37277e74562c7c9bf93ae7136cb360f28df7e4e2a8ef3d067c8182776557d3",
+  "iso_name": "dfly-x86_64-4.6.1_REL.iso",
+  "iso_url": "http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-4.6.1_REL.iso",
   "hostname": "dfly46",
   "vm_name": "dfly46"
 }


### PR DESCRIPTION
- Updated to DragonFly BSD 4.6.1
- Added support for _Parallels Desktop for Mac_
