### PR TITLE
Removed EOL versions and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ BSD Vagrant boxes.
 
 ## Current Boxes
 
-* [FreeBSD 10.2 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/freebsd102)
-* [OpenBSD 5.8 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/openbsd58)
+* [FreeBSD 10.3 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/freebsd103)
+* [FreeBSD 11.0 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/freebsd110)
 * [OpenBSD 5.9 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/openbsd59)
+* [OpenBSD 6.0 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/openbsd60)
+* [NetBSD 7.0.1 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/netbsd70)
+* [DragonFlyBSD 4.6 (64-bit)](https://atlas.hashicorp.com/boxcutter/boxes/dragonflybsd46)
 
 ## Building the Vagrant boxes with Packer
 
@@ -26,6 +29,7 @@ There are currently base Packer templates for the supported BSD flavors:
 - freebsd.json
 - openbsd.json
 - netbsd.json
+- dragonflybsd.json
 
 NOTE: The NetBSD box times out on `vagrant up` waiting on SSH, but `vagrant ssh` works fine. This seems to be a vagrant issue, see [mitchellh/vagrant#6640](https://github.com/mitchellh/vagrant/issues/6640).
 

--- a/freebsd102.json
+++ b/freebsd102.json
@@ -1,7 +1,0 @@
-{
-  "_comment": "Build with `packer build -var-file=freebsd102.json freebsd.json`",
-  "iso_checksum": "97908f5cd00d86cafeb2c265bfabbd0aa79f87e9b6b31ecdb756bc96a4a62e93",
-  "iso_name": "FreeBSD-10.2-RELEASE-amd64-disc1.iso",
-  "iso_url": "http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/10.2/FreeBSD-10.2-RELEASE-amd64-disc1.iso",
-  "vm_name": "freebsd102"
-}

--- a/freebsd93.json
+++ b/freebsd93.json
@@ -1,7 +1,0 @@
-{
-  "_comment": "Build with `packer build -var-file=freebsd93.json freebsd.json`",
-  "iso_checksum": "5a3c82653d77bba7d7ded8bd7efbedc09d52cf4045d98ce52a82c9e0f8fa9b0e",
-  "iso_name": "FreeBSD-9.3-RELEASE-amd64-disc1.iso",
-  "iso_url": "http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/9.3/FreeBSD-9.3-RELEASE-amd64-disc1.iso",
-  "vm_name": "freebsd93"
-}

--- a/openbsd58.json
+++ b/openbsd58.json
@@ -1,7 +1,0 @@
-{
-  "_comment": "Build with `packer build openbsd58.json`",
-  "iso_checksum": "2edd369c4b5f1960f9c974ee7f7bbe4105137968c1542d37411e83cb79f7f6f2",
-  "iso_name": "install58.iso",
-  "iso_url": "http://ftp.eu.openbsd.org/pub/OpenBSD/5.8/amd64/install58.iso",
-  "vm_name": "openbsd58"
-}


### PR DESCRIPTION
Removed:
- OpenBSD 5.8
- FreeBSD 9.3
- FreeBSD 10.2