### PR TITLE
fix device name typo

### DIFF
--- a/dragonflybsd.json
+++ b/dragonflybsd.json
@@ -7,7 +7,7 @@
         "<wait10><wait10><wait10>",
         "root<enter>dhclient em0<enter><wait>",
         "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `install_path` }}",
-        " && sh /tmp/install.sh da0 {{ user `hostname`}} vagrant",
+        " && sh /tmp/install.sh ad0 {{ user `hostname`}} vagrant",
         " {{ user `ssh_password` }} \"{{ user `ssh_fullname` }}\"<enter>"
       ],
       "boot_wait": "6s",
@@ -49,7 +49,7 @@
         "<wait10><wait10><wait10>",
         "root<enter>dhclient em0<enter><wait>",
         "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `install_path` }}",
-        " && sh /tmp/install.sh da0 {{ user `hostname`}} vagrant",
+        " && sh /tmp/install.sh ad0 {{ user `hostname`}} vagrant",
         " {{ user `ssh_password` }} \"{{ user `ssh_fullname` }}\"<enter>"
       ],
       "boot_wait": "6s",


### PR DESCRIPTION
When I run packer, I see an I/O error around the "da0" disk. When I fix the device name to "ad0", then packer can get further along in the builds.