### PR TITLE
Fix openbsd63

### DIFF
--- a/openbsd63.json
+++ b/openbsd63.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build openbsd63.json`",
-  "iso_checksum": "dbeae81c53dc7d0aacd47cb55a40d4fb68c23aea64e33fa04e63cac32c1b7795",
+  "iso_checksum": "ee775405dd7926975befbc3fef23de8c4b5a726c3b5075e4848fcd3a2a712ea8",
   "iso_name": "install63.iso",
   "iso_url": "http://ftp.eu.openbsd.org/pub/OpenBSD/6.3/amd64/install63.iso",
   "vm_name": "openbsd63"

--- a/openbsd65.json
+++ b/openbsd65.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Build with `packer build -var-file openbsd65.json openbsd.json`",
+  "iso_checksum": "38d1f8cadd502f1c27bf05c5abde6cc505dd28f3f34f8a941048ff9a54f9f608",
+  "iso_name": "install65.iso",
+  "iso_url": "https://mirrors.gigenet.com/pub/OpenBSD/6.5/amd64/install65.iso",
+  "vm_name": "openbsd65"
+}


### PR DESCRIPTION
The checksum for the OpenBSD 6.3 install ISO is incorrect.  This PR fixes that.