### PR TITLE
Remove deprecated iso_checksum_type configuration key

### DIFF
--- a/dragonflybsd.json
+++ b/dragonflybsd.json
@@ -21,7 +21,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -58,7 +57,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -91,7 +89,6 @@
       "hard_drive_interface": "ide",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -167,7 +164,6 @@
     "https_proxy": "{{env `https_proxy`}}",
     "install_vagrant_key": "true",
     "iso_checksum": "",
-    "iso_checksum_type": "sha256",
     "iso_name": "",
     "iso_path": "/Volumes/Storage/software/dragonflybsd",
     "iso_url": "",

--- a/dragonflybsd52.json
+++ b/dragonflybsd52.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build -var-file=dragonflybsd52.json dragonflybsd.json`",
-  "iso_checksum": "c5679c73e76aa5715590039e1dce36e056ab692b81585fc13387d3b7c251d734",
+  "iso_checksum": "sha256:c5679c73e76aa5715590039e1dce36e056ab692b81585fc13387d3b7c251d734",
   "iso_name": "dfly-x86_64-5.2.1_REL.iso",
   "iso_url": "http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.2.1_REL.iso",
   "hostname": "dfly52",

--- a/freebsd.json
+++ b/freebsd.json
@@ -24,7 +24,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -64,7 +63,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -99,7 +97,6 @@
       "guest_os_type": "{{ user `parallels_guest_os_type` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -183,7 +180,6 @@
     "https_proxy": "{{env `https_proxy`}}",
     "install_vagrant_key": "true",
     "iso_checksum": "",
-    "iso_checksum_type": "sha256",
     "iso_name": "",
     "iso_path": "/Volumes/Storage/software/freebsd",
     "iso_url": "",

--- a/freebsd104.json
+++ b/freebsd104.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build -var-file=freebsd104.json freebsd.json`",
-  "iso_checksum": "7ac73b2a899024e1d9e71e55b5c9b9ac13938468206c72c5a1cf23c7e0a715b4",
+  "iso_checksum": "sha256:7ac73b2a899024e1d9e71e55b5c9b9ac13938468206c72c5a1cf23c7e0a715b4",
   "iso_name": "FreeBSD-10.4-RELEASE-amd64-disc1.iso",
   "iso_url": "http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/10.4/FreeBSD-10.4-RELEASE-amd64-disc1.iso",
   "vm_name": "freebsd104"

--- a/freebsd111.json
+++ b/freebsd111.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build -var-file=freebsd111.json freebsd.json`",
-  "iso_checksum": "ff4c749ea0aaaceedb2432ba3e0fd0c1b64f5a72141b1ec06b9ced52b5de0dbf",
+  "iso_checksum": "sha256:ff4c749ea0aaaceedb2432ba3e0fd0c1b64f5a72141b1ec06b9ced52b5de0dbf",
   "iso_name": "FreeBSD-11.1-RELEASE-amd64-disc1.iso",
   "iso_url": "http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/11.1/FreeBSD-11.1-RELEASE-amd64-disc1.iso",
   "vm_name": "freebsd111"

--- a/netbsd.json
+++ b/netbsd.json
@@ -27,7 +27,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -70,7 +69,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -108,7 +106,6 @@
       "guest_os_type": "{{ user `parallels_guest_os_type` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -187,7 +184,6 @@
     "https_proxy": "{{env `https_proxy`}}",
     "install_vagrant_key": "true",
     "iso_checksum": "",
-    "iso_checksum_type": "sha256",
     "iso_name": "",
     "iso_path": "/Volumes/Thunder/software/netbsd",
     "iso_url": "",

--- a/netbsd71.json
+++ b/netbsd71.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build netbsd71.json`",
-  "iso_checksum": "2a0cbc16202d565c0fabc08d2f70b21db886467671d215fa30f13d0c87371843",
+  "iso_checksum": "sha256:2a0cbc16202d565c0fabc08d2f70b21db886467671d215fa30f13d0c87371843",
   "iso_name": "NetBSD-7.1.2-amd64.iso",
   "iso_url": "http://ftp.fi.netbsd.org/pub/NetBSD/NetBSD-7.1.2/iso/NetBSD-7.1.2-amd64.iso",
   "netbsd_mirror": "http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD",

--- a/openbsd.json
+++ b/openbsd.json
@@ -21,7 +21,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -58,7 +57,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -91,7 +89,6 @@
       "hard_drive_interface": "ide",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -176,7 +173,6 @@
     "https_proxy": "{{env `https_proxy`}}",
     "install_vagrant_key": "true",
     "iso_checksum": "",
-    "iso_checksum_type": "sha256",
     "iso_name": "",
     "iso_path": "/Volumes/Thunder/software/openbsd",
     "iso_url": "",

--- a/openbsd63.json
+++ b/openbsd63.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build openbsd63.json`",
-  "iso_checksum": "ee775405dd7926975befbc3fef23de8c4b5a726c3b5075e4848fcd3a2a712ea8",
+  "iso_checksum": "sha256:ee775405dd7926975befbc3fef23de8c4b5a726c3b5075e4848fcd3a2a712ea8",
   "iso_name": "install63.iso",
   "iso_url": "http://ftp.eu.openbsd.org/pub/OpenBSD/6.3/amd64/install63.iso",
   "vm_name": "openbsd63"

--- a/openbsd65.json
+++ b/openbsd65.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build -var-file openbsd65.json openbsd.json`",
-  "iso_checksum": "38d1f8cadd502f1c27bf05c5abde6cc505dd28f3f34f8a941048ff9a54f9f608",
+  "iso_checksum": "sha256:38d1f8cadd502f1c27bf05c5abde6cc505dd28f3f34f8a941048ff9a54f9f608",
   "iso_name": "install65.iso",
   "iso_url": "https://mirrors.gigenet.com/pub/OpenBSD/6.5/amd64/install65.iso",
   "vm_name": "openbsd65"


### PR DESCRIPTION
Modern versions of `packer` are not too happy to see the `iso_checksum_type` config key:
```
Error: Failed to prepare build: "virtualbox-iso"

1 error occurred:
        * Deprecated configuration key: 'iso_checksum_type'. Please call `packer fix`
against your template to update your template to be compatible with the current
version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more
detail.
```

After removing the old keys and moving the type into the `iso_checksum` key, `packer fix` makes no changes to the configuration files.