### PR TITLE
Update freebsd versions

### DIFF
--- a/dragonflybsd.json
+++ b/dragonflybsd.json
@@ -21,7 +21,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -58,7 +57,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -91,7 +89,6 @@
       "hard_drive_interface": "ide",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -167,7 +164,6 @@
     "https_proxy": "{{env `https_proxy`}}",
     "install_vagrant_key": "true",
     "iso_checksum": "",
-    "iso_checksum_type": "sha256",
     "iso_name": "",
     "iso_path": "/Volumes/Storage/software/dragonflybsd",
     "iso_url": "",

--- a/dragonflybsd52.json
+++ b/dragonflybsd52.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build -var-file=dragonflybsd52.json dragonflybsd.json`",
-  "iso_checksum": "c5679c73e76aa5715590039e1dce36e056ab692b81585fc13387d3b7c251d734",
+  "iso_checksum": "sha256:c5679c73e76aa5715590039e1dce36e056ab692b81585fc13387d3b7c251d734",
   "iso_name": "dfly-x86_64-5.2.1_REL.iso",
   "iso_url": "http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.2.1_REL.iso",
   "hostname": "dfly52",

--- a/freebsd.json
+++ b/freebsd.json
@@ -24,7 +24,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -64,7 +63,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -99,7 +97,6 @@
       "guest_os_type": "{{ user `parallels_guest_os_type` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -183,7 +180,6 @@
     "https_proxy": "{{env `https_proxy`}}",
     "install_vagrant_key": "true",
     "iso_checksum": "",
-    "iso_checksum_type": "sha256",
     "iso_name": "",
     "iso_path": "/Volumes/Storage/software/freebsd",
     "iso_url": "",

--- a/freebsd104.json
+++ b/freebsd104.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build -var-file=freebsd104.json freebsd.json`",
-  "iso_checksum": "7ac73b2a899024e1d9e71e55b5c9b9ac13938468206c72c5a1cf23c7e0a715b4",
+  "iso_checksum": "sha256:7ac73b2a899024e1d9e71e55b5c9b9ac13938468206c72c5a1cf23c7e0a715b4",
   "iso_name": "FreeBSD-10.4-RELEASE-amd64-disc1.iso",
   "iso_url": "http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/10.4/FreeBSD-10.4-RELEASE-amd64-disc1.iso",
   "vm_name": "freebsd104"

--- a/freebsd111.json
+++ b/freebsd111.json
@@ -1,7 +1,0 @@
-{
-  "_comment": "Build with `packer build -var-file=freebsd111.json freebsd.json`",
-  "iso_checksum": "sha256:ff4c749ea0aaaceedb2432ba3e0fd0c1b64f5a72141b1ec06b9ced52b5de0dbf",
-  "iso_name": "FreeBSD-11.1-RELEASE-amd64-disc1.iso",
-  "iso_url": "http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/11.1/FreeBSD-11.1-RELEASE-amd64-disc1.iso",
-  "vm_name": "freebsd111"
-}

--- a/freebsd111.json
+++ b/freebsd111.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build -var-file=freebsd111.json freebsd.json`",
-  "iso_checksum": "ff4c749ea0aaaceedb2432ba3e0fd0c1b64f5a72141b1ec06b9ced52b5de0dbf",
+  "iso_checksum": "sha256:ff4c749ea0aaaceedb2432ba3e0fd0c1b64f5a72141b1ec06b9ced52b5de0dbf",
   "iso_name": "FreeBSD-11.1-RELEASE-amd64-disc1.iso",
   "iso_url": "http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/11.1/FreeBSD-11.1-RELEASE-amd64-disc1.iso",
   "vm_name": "freebsd111"

--- a/freebsd114.json
+++ b/freebsd114.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Build with `packer build -var-file=freebsd114.json freebsd.json`",
+  "iso_checksum": "sha256:d76c1ded99b2c1005b1ff94cc0c811fbcd8a2d04196432009ab5f203c2146914",
+  "iso_name": "FreeBSD-11.4-RELEASE-amd64-disc1.iso",
+  "iso_url": "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/11.4/FreeBSD-11.4-RELEASE-amd64-disc1.iso",
+  "vm_name": "freebsd114"
+}

--- a/freebsd122.json
+++ b/freebsd122.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Build with `packer build -var-file=freebsd122.json freebsd.json`",
+  "iso_checksum": "sha256:289522e2f4e1260859505adab6d7b54ab83d19aeb147388ff7e28019984da5dc",
+  "iso_name": "FreeBSD-12.2-RELEASE-amd64-disc1.iso",
+  "iso_url": "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/12.2/FreeBSD-12.2-RELEASE-amd64-disc1.iso",
+  "vm_name": "freebsd122"
+}

--- a/freebsd130.json
+++ b/freebsd130.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Build with `packer build -var-file=freebsd130.json freebsd.json`",
+  "iso_checksum": "sha256:f78d4e5f53605592863852b39fa31a12f15893dc48cacecd875f2da72fa67ae5",
+  "iso_name": "FreeBSD-13.0-RELEASE-amd64-disc1.iso",
+  "iso_url": "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/13.0/FreeBSD-13.0-RELEASE-amd64-disc1.iso",
+  "vm_name": "freebsd130"
+}

--- a/netbsd.json
+++ b/netbsd.json
@@ -27,7 +27,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -70,7 +69,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -108,7 +106,6 @@
       "guest_os_type": "{{ user `parallels_guest_os_type` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -187,7 +184,6 @@
     "https_proxy": "{{env `https_proxy`}}",
     "install_vagrant_key": "true",
     "iso_checksum": "",
-    "iso_checksum_type": "sha256",
     "iso_name": "",
     "iso_path": "/Volumes/Thunder/software/netbsd",
     "iso_url": "",

--- a/netbsd71.json
+++ b/netbsd71.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build netbsd71.json`",
-  "iso_checksum": "2a0cbc16202d565c0fabc08d2f70b21db886467671d215fa30f13d0c87371843",
+  "iso_checksum": "sha256:2a0cbc16202d565c0fabc08d2f70b21db886467671d215fa30f13d0c87371843",
   "iso_name": "NetBSD-7.1.2-amd64.iso",
   "iso_url": "http://ftp.fi.netbsd.org/pub/NetBSD/NetBSD-7.1.2/iso/NetBSD-7.1.2-amd64.iso",
   "netbsd_mirror": "http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD",

--- a/openbsd.json
+++ b/openbsd.json
@@ -21,7 +21,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -58,7 +57,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -91,7 +89,6 @@
       "hard_drive_interface": "ide",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -176,7 +173,6 @@
     "https_proxy": "{{env `https_proxy`}}",
     "install_vagrant_key": "true",
     "iso_checksum": "",
-    "iso_checksum_type": "sha256",
     "iso_name": "",
     "iso_path": "/Volumes/Thunder/software/openbsd",
     "iso_url": "",

--- a/openbsd63.json
+++ b/openbsd63.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build openbsd63.json`",
-  "iso_checksum": "ee775405dd7926975befbc3fef23de8c4b5a726c3b5075e4848fcd3a2a712ea8",
+  "iso_checksum": "sha256:ee775405dd7926975befbc3fef23de8c4b5a726c3b5075e4848fcd3a2a712ea8",
   "iso_name": "install63.iso",
   "iso_url": "http://ftp.eu.openbsd.org/pub/OpenBSD/6.3/amd64/install63.iso",
   "vm_name": "openbsd63"

--- a/openbsd65.json
+++ b/openbsd65.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Build with `packer build -var-file openbsd65.json openbsd.json`",
-  "iso_checksum": "38d1f8cadd502f1c27bf05c5abde6cc505dd28f3f34f8a941048ff9a54f9f608",
+  "iso_checksum": "sha256:38d1f8cadd502f1c27bf05c5abde6cc505dd28f3f34f8a941048ff9a54f9f608",
   "iso_name": "install65.iso",
   "iso_url": "https://mirrors.gigenet.com/pub/OpenBSD/6.5/amd64/install65.iso",
   "vm_name": "openbsd65"


### PR DESCRIPTION
NOTE: This PR is currently based off of #43, and will be rebased to remove that commit once it merges.

Update the FreeBSD 11.1 template to 11.4 and add templates for 12.2 and 13.0.

I tested by building all three of these images using the `virtualbox-iso` builder and booting into each of them, but since there was nothing exotic in the templates I didn't bother building with vmware or parallels.

114:
```
$ packer build -only=virtualbox-iso -var-file=freebsd114.json freebsd.json
...
==> Builds finished. The artifacts of successful builds are:
--> virtualbox-iso: 'virtualbox' provider box: box/virtualbox/freebsd114-0.1.0.box
$ vagrant box add testing/freebsd114 box/virtualbox/freebsd114-0.1.0.box
==> box: Box file was not detected as metadata. Adding it directly...
==> box: Adding box 'testing/freebsd114' (v0) for provider:
    box: Unpacking necessary files from: file:///Users/cpatton/boxcutter-bsd/box/virtualbox/freebsd114-0.1.0.box
==> box: Successfully added box 'testing/freebsd114' (v0) for 'virtualbox'!
$ cat Vagrantfile
Vagrant.configure("2") do |config|
  config.vm.box = "testing/freebsd114"
end
$ vagrant up
...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
...
$ vagrant ssh -c 'uname -mrs'
FreeBSD 11.4-RELEASE-p9 amd64
Connection to 127.0.0.1 closed.
```

122:
```
$ packer build -only=virtualbox-iso -var-file=freebsd122.json freebsd.json
...
==> Builds finished. The artifacts of successful builds are:
--> virtualbox-iso: 'virtualbox' provider box: box/virtualbox/freebsd122-0.1.0.box
$ vagrant box add testing/freebsd122 box/virtualbox/freebsd122-0.1.0.box
==> box: Box file was not detected as metadata. Adding it directly...
==> box: Adding box 'testing/freebsd122' (v0) for provider:
    box: Unpacking necessary files from: file:///Users/cpatton/boxcutter-bsd/box/virtualbox/freebsd122-0.1.0.box
==> box: Successfully added box 'testing/freebsd122' (v0) for 'virtualbox'!
$ cat Vagrantfile
Vagrant.configure("2") do |config|
  config.vm.box = "testing/freebsd122"
end
$ vagrant up
...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
...
$ vagrant ssh -c 'uname -mrs'
FreeBSD 12.2-RELEASE-p7 amd64
Connection to 127.0.0.1 closed.
```

130:
```
$ packer build -only=virtualbox-iso -var-file=freebsd130.json freebsd.json
...
==> Builds finished. The artifacts of successful builds are:
--> virtualbox-iso: 'virtualbox' provider box: box/virtualbox/freebsd130-0.1.0.box
$ vagrant box add testing/freebsd130 box/virtualbox/freebsd130-0.1.0.box
==> box: Box file was not detected as metadata. Adding it directly...
==> box: Adding box 'testing/freebsd130' (v0) for provider:
    box: Unpacking necessary files from: file:///Users/cpatton/boxcutter-bsd/box/virtualbox/freebsd130-0.1.0.box
==> box: Successfully added box 'testing/freebsd130' (v0) for 'virtualbox'!
$ cat Vagrantfile
Vagrant.configure("2") do |config|
  config.vm.box = "testing/freebsd130"
end
$ vagrant up
...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
...
$ vagrant ssh -c 'uname -mrs'
FreeBSD 13.0-RELEASE-p3 amd64
Connection to 127.0.0.1 closed.
```